### PR TITLE
memset関数を削減

### DIFF
--- a/include/RtORB/corba-seq.hh
+++ b/include/RtORB/corba-seq.hh
@@ -242,7 +242,7 @@ namespace CORBA_sequence {
       if (n <= 0) { return 0; }
       
       if (impl->_buffer == NULL) {
-	Elem *newbuf= (Elem *)RtORB_calloc(sizeof(Elem), n,  "CORBA_sequenct::T_Seq::length");
+  Elem *newbuf= (Elem *)RtORB_alloc(n*sizeof(Elem),  "CORBA_sequenct::T_Seq::length");
 	for (i=0; i<n; i++) {
 	  ElemHelper::nil(newbuf[i]);
 	}
@@ -253,7 +253,6 @@ namespace CORBA_sequence {
 	size_t oldsize = impl->_length * sizeof(Elem);
 	size_t newsize = n * sizeof(Elem);
 	Elem * newbuf = (Elem*)RtORB_realloc(impl->_buffer, newsize, "CORBA_sequenct::T_Seq::length");
-	memset(newbuf + impl->_length, 0x00, newsize - oldsize);
 	for (i=impl->_length; i<n; i++) {
 	  ElemHelper::nil(newbuf[i]);
 	}

--- a/include/RtORB/corba.h
+++ b/include/RtORB/corba.h
@@ -109,7 +109,7 @@ extern "C"
 #  define RtORB_strndup(s, n, info)	RtORB__strndup(s, n, info)
 #  define RtORB_free(s, info)		RtORB__free(s, info)
 #else
-#  define RtORB_alloc(s, info)		calloc(1, s)
+#  define RtORB_alloc(s, info)		malloc(s)
 #  define RtORB_realloc(p, s, info)	realloc(p, s)
 #  define RtORB_calloc(s, n, info)	calloc(n, s)
 #  define RtORB_strdup(s, info)		strdup(s)

--- a/lib/CXX/cdrStream.cpp
+++ b/lib/CXX/cdrStream.cpp
@@ -105,7 +105,6 @@ void *cdrStream::unmarshal_sequence(int32_t size, CORBA_TypeCode tc){
   CORBA_TypeCode _tc=tc->member_type[0]; 
 
   res = RtORB_alloc(_tc->size * size, "unmarshal_sequence");
-  memset(res, 0, _tc->size * size);
 
   _ptr = (char *)res;
   len=12;

--- a/lib/corba-sequence.c
+++ b/lib/corba-sequence.c
@@ -102,7 +102,7 @@ CORBA_SequenceBase *CORBA_SequenceBase__new(int _max, int _len){
   seq->_length = _len;
   seq->_maximum = _max;
   seq->_release = 0;
-  seq->_buffer = (void **)RtORB_calloc( sizeof(void **), _max, "CORBA_Sequence__new");
+  seq->_buffer = (void **)RtORB_alloc(_max*sizeof(void **), "CORBA_Sequence__new");
   return seq;
 }
 
@@ -131,7 +131,6 @@ void CORBA_SequenceBase__clear(CORBA_SequenceBase *seq, void (*_free)()){
 	  ((free_func_type)_free)(seq->_buffer[i], "CORBA_SequenceBase__clear");
   }
   seq->_length = 0;
-  memset(seq->_buffer, 0, seq->_maximum);
   return ;
 }
 

--- a/lib/giop-marshal.c
+++ b/lib/giop-marshal.c
@@ -874,8 +874,7 @@ demarshal_by_typecode(void **dist, CORBA_TypeCode tc, octet *buf, int *current, 
 	    {
               char *buf_ = NULL;
 
-              buf_ = (char *)RtORB_alloc( 4096, "demarshal_by_typecode:tk_any" );
-              memset(buf, 0, 4096);
+        buf_ = (char *)RtORB_alloc( 4096, "demarshal_by_typecode:tk_any" );
 
 	      int len = 0;
 	      marshal_by_typecode((octet *)buf_, ptr, tc_, &len);
@@ -1323,7 +1322,6 @@ Marshal_Reply_Arguments(GIOP_ReplyBody *reply,
      fprintf(stderr, "Error in Marshal_Reply_Arguments: Fail to allocate buffer...\n");
     return;
    }
-   memset(reply_buf, 0, MaxSize);
 
    Marshal_Result(reply_buf, result, m->retval, &size);
 #ifdef DEBUG_MARSHAL
@@ -1381,7 +1379,6 @@ static int marshal_typecode(octet *buf, int *current, CORBA_TypeCode tc)
       octet *buf_ = NULL;
 
       buf_ = ( octet* )RtORB_alloc( 4096, "marshal_typecode(PLT_COMPLEX)");
-      memset(buf_, 0, 4096); 
 	  
       switch(tc->kind) {
       case tk_string:

--- a/lib/giop-msg.c
+++ b/lib/giop-msg.c
@@ -144,7 +144,6 @@ CORBA_Sequence_Octet *new_CORBA_Sequence_Octet(int size){
   seq->_release = 0;
   if(size > 0){
     seq->_buffer = (octet *)RtORB_alloc(size, "new_CORBA_Sequence_Octet(buffer)");
-    memset(seq->_buffer, 0, size);
   }else{
     seq->_buffer = (octet *)NULL;
   }
@@ -159,7 +158,6 @@ CORBA_Sequence_Octet *new_CORBA_Sequence_Octet2(int size){
   seq->_release = 0;
   if(size > 0){
     seq->_buffer = (octet *)RtORB_alloc(size, "new_CORBA_Sequence_Octet(buffer)");
-    memset(seq->_buffer, 0, size);
   }else{
     seq->_buffer = (octet *)NULL;
   }

--- a/lib/giop.c
+++ b/lib/giop.c
@@ -189,7 +189,6 @@ int reply_Message(GIOP_ConnectionHandler *h, GIOP_RequestHeader *request_header,
     fprintf(stderr, "ERROR in reply_Message: Fail to allocate buffer(%d)\n", alloc_size);
     return -1;
   }
-  memset(msgbuf, 0, alloc_size);
 
   if (version < 2){
     header._1_0.service_context.num = 0;
@@ -389,7 +388,6 @@ GIOP_ReplyBody *invokeServant(PortableServer_POA poa,
            char *reply_buf = NULL;
 	   int size = 0;
            reply_buf = (char *)RtORB_alloc( MaxMessageSize, "invokeServant(USER_EXCEPTION)");
-           memset(reply_buf, 0, MaxMessageSize );
 
 	   fprintf(stderr, "User exception(%s): %s\n",
 			   function, env->_repo_id);
@@ -453,7 +451,6 @@ int reply_locateMessage(PortableServer_POA poa, GIOP_ConnectionHandler *h,
   char *ior = NULL;   /* Not use */
   
   buf = (unsigned char *)RtORB_alloc( MaxMessageSize, "reply_locateMessage");
-  memset(buf, 0, MaxMessageSize);
   
   GIOP_LocateReplyHeader header;
   if (version < 2){
@@ -489,7 +486,6 @@ uint32_t createRequest(octet *buf, int response,
 
   GIOP_RequestHeader *header = (GIOP_RequestHeader *)newRequestHeader();
 
-  memset(buf, 0, MaxMessageSize);
 
   GIOP_MessageHeader *MsgHeader = GIOP_Create_MessageHeader(RTORB_BYTE_ORDER, version);
   MsgHeader->message_type = GIOP_Request ;
@@ -525,7 +521,6 @@ uint32_t createCancelRequest(octet *buf, uint32_t request_id)
   uint32_t version = 2;
   int current = SIZEOF_GIOP_HEADER;
 
-  memset(buf, 0, MaxMessageSize);
 
   GIOP_MessageHeader *MsgHeader = GIOP_Create_MessageHeader(RTORB_BYTE_ORDER, version);
   MsgHeader->message_type = GIOP_CancelRequest ;
@@ -544,7 +539,6 @@ int createLocateRequest(octet *buf, char *object_key, int len){
   int version = 2;
   GIOP_LocateRequestHeader Header;
 
-  memset(buf, 0, MaxMessageSize);
 
   GIOP_MessageHeader *MsgHeader = GIOP_Create_MessageHeader(RTORB_BYTE_ORDER, version);
   MsgHeader->message_type = GIOP_LocateRequest ;
@@ -577,7 +571,6 @@ uint32_t createCloseConnectionMessage(octet *buf)
 {
   uint32_t version = 2;
 
-  memset(buf, 0, MaxMessageSize);
 
   GIOP_MessageHeader *MsgHeader = GIOP_Create_MessageHeader(RTORB_BYTE_ORDER, version);
   MsgHeader->message_type = GIOP_CloseConnection ;
@@ -594,7 +587,6 @@ uint32_t createCloseConnectionMessage(octet *buf)
 uint32_t createMessageErrorMessage(octet *buf){
   uint32_t version = 0;
 
-  memset(buf, 0, MaxMessageSize);
 
   GIOP_MessageHeader *MsgHeader = GIOP_Create_MessageHeader(RTORB_BYTE_ORDER, version);
   MsgHeader->message_type = GIOP_MessageError ;
@@ -619,7 +611,6 @@ int requestLocation(GIOP_ConnectionHandler *h, CORBA_URL *ior){
     fprintf(stderr, "ERROR in requestLocation: Fail to allocate buffer..\n");
     return -1;
   }
-  memset(buf, 0, MaxMessageSize);
 
   len = createLocateRequest((octet *)buf, ior->object_key, ior->object_key_len);
   ret = GIOP_ConnectionHandler_send(h, buf, len);
@@ -644,12 +635,10 @@ int confirmLocation(GIOP_ConnectionHandler *h, CORBA_URL *ior){
     fprintf(stderr, "ERROR in confirmLocation: Fail to allocate buffer..\n");
     return -1;
   }
-  memset(buf, 0, MaxMessageSize);
 
   len = createLocateRequest((octet *)buf, ior->object_key, ior->object_key_len);
   GIOP_ConnectionHandler_send(h, buf, len);
 
-  memset(buf, 0, MaxMessageSize);
 
   if(receiveMessage(h, &header, (octet *)buf, MaxMessageSize) < 0){
     RtORB_free( buf , "confirmLocation:receiveMessage");
@@ -916,7 +905,6 @@ PtrList *GIOP_enqueue_request(GIOP_ConnectionHandler *h, PtrList *lst){
 #endif
 
   buf = ( char* )RtORB_alloc( RECV_BUF_SIZE, "GIOP_enqueue_request");
-  memset(buf, 0, RECV_BUF_SIZE);
 
 
   if(receiveMessage(h, &header, (octet *)buf, RECV_BUF_SIZE) < 0){
@@ -963,7 +951,6 @@ int RecvMessage(GIOP_ConnectionHandler *h){
   }
 
   memset(&header, 0, SIZEOF_GIOP_HEADER);
-  memset(recvbuf, 0, recvBufSize);
 
   body = (CORBA_Sequence_Octet *)new_CORBA_Sequence_Octet(0);
 

--- a/lib/rtorb.c
+++ b/lib/rtorb.c
@@ -152,7 +152,6 @@ void invokeMethod_via_GIOP(CORBA_Object obj,
   GIOP_ConnectionHandler_send(h, (char *)req_buf, len);
 
   memset(&header, 0, SIZEOF_GIOP_HEADER);
-  memset(buf, 0, MaxMessageSize);
 
   /*  receive reply */
   if(receiveMessage(h, &header, (octet *)buf, MaxMessageSize) < 0){


### PR DESCRIPTION
`memset`関数、`calloc`関数でブロックを0にする処理が大きな負担になっているため、`memset`関数を極力削除、`calloc`関数を`malloc`関数に可能な限り置き換えた。