### PR TITLE
復号時に発生する問題の修正

### DIFF
--- a/lib/giop-marshal.c
+++ b/lib/giop-marshal.c
@@ -155,8 +155,7 @@ uint32_t size_of_typecode(CORBA_TypeCode tc, int flag)
        return sizeof(CORBA_Object);
 
     case tk_string:
-       if(flag == F_MARSHAL) return 4;
-       return sizeof(void *);
+       return 4;
 
     default:
       if (tc->size) return tc->size;
@@ -189,7 +188,6 @@ uint32_t align_of_typecode(CORBA_TypeCode tc, int flag)
        }
        return max_align;
     case tk_string:
-       if(flag == F_MARSHAL) return 4;
        return 4;
     default:
       if (tc->alignment) return tc->alignment;

--- a/lib/giop-marshal.c
+++ b/lib/giop-marshal.c
@@ -190,7 +190,7 @@ uint32_t align_of_typecode(CORBA_TypeCode tc, int flag)
        return max_align;
     case tk_string:
        if(flag == F_MARSHAL) return 4;
-       return sizeof(void *);
+       return 4;
     default:
       if (tc->alignment) return tc->alignment;
       else return 1;


### PR DESCRIPTION
64bit環境でビルドすると#1 のように復号に失敗する。
64bitと32bitでvoidのサイズが違うのが原因のため修正した。