### PR TITLE
socket.cのバグの修正

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -129,7 +129,7 @@ int copy_fds_set(fd_set *target, fd_set *src){
   int k;
   int	 nfds = 1;
 
-  for(k= FD_SETSIZE; k >0 ;k--){
+  for(k= FD_SETSIZE-1; k >0 ;k--){
     if(FD_ISSET(k, src)){
       FD_SET(k, target);
       if(nfds < k) nfds = k+1;


### PR DESCRIPTION
ビルドオプションが`-O0`でないと異常終了することがある。
これはsocket.cで配列の長さ以上の要素にアクセスしようとすることが原因のため修正した。