### PR TITLE
通信が異常に遅い問題の修正

### DIFF
--- a/lib/giop.c
+++ b/lib/giop.c
@@ -1159,8 +1159,9 @@ int32_t GIOP_ConnectionHandler_send(GIOP_ConnectionHandler *h, char *buf, int32_
       res=write(h->sock, buf, len);
       fprintf(stderr, "Send Data %d (%d)\n", h->sock, res);
 #else
-      res = writeBytes(h->sock, buf, 12);
-      res += writeBytes(h->sock, buf+12, len-12);
+      //res = writeBytes(h->sock, buf, 12);
+      //res += writeBytes(h->sock, buf+12, len-12);
+      res += writeBytes(h->sock, buf, len);
 #endif
       return res;
 

--- a/lib/giop.c
+++ b/lib/giop.c
@@ -1159,8 +1159,6 @@ int32_t GIOP_ConnectionHandler_send(GIOP_ConnectionHandler *h, char *buf, int32_
       res=write(h->sock, buf, len);
       fprintf(stderr, "Send Data %d (%d)\n", h->sock, res);
 #else
-      //res = writeBytes(h->sock, buf, 12);
-      //res += writeBytes(h->sock, buf+12, len-12);
       res += writeBytes(h->sock, buf, len);
 #endif
       return res;


### PR DESCRIPTION
#4 のように通信が異常に遅くなるため、GIOPのヘッダーとデータを別々に送信している箇所を変更して一度に送信するようにした。