### PR TITLE
cdrStreamの読み込み位置と書き込み位置を区別する

### DIFF
--- a/include/RtORB/cdrStream.h
+++ b/include/RtORB/cdrStream.h
@@ -83,6 +83,7 @@ public:
 
  void *out_buf;             /*!< (TODO) */
  uint32_t out_len;    /*!< (TODO) */
+ uint32_t in_c;      /*!< (TODO) */
  uint32_t out_c;      /*!< (TODO) */
  uint32_t byte_order;  /*!< (TODO) */
 

--- a/lib/CXX/cdrStream.cpp
+++ b/lib/CXX/cdrStream.cpp
@@ -69,7 +69,7 @@ PARAM_LIST_TYPE(unsigned int kind){
   cdrStream
 */
 
-cdrStream::cdrStream(): out_buf(0),out_len(0),out_c(0),byte_order(0){
+cdrStream::cdrStream(): out_buf(0),out_len(0),out_c(0),in_c(0),byte_order(0){
 }
 
 cdrStream::~cdrStream(){
@@ -452,6 +452,7 @@ CORBA_Object cdrStream::unmarshal_CORBA_Object(){
 cdrMemoryStream::cdrMemoryStream(int32_t initBufsize, int32_t clsMemory)
 {
   out_c=0;
+  in_c=0;
   byte_order=0;
 
   if(initBufsize){
@@ -469,6 +470,7 @@ cdrMemoryStream::cdrMemoryStream(int32_t initBufsize, int32_t clsMemory)
 cdrMemoryStream::cdrMemoryStream(void *databuffer, int32_t maxLen)
 {
   out_c=0;
+  in_c=0;
   byte_order=0;
 
   out_buf = RtORB_alloc(maxLen, "cdrMemoryStream");
@@ -479,6 +481,7 @@ cdrMemoryStream::cdrMemoryStream(void *databuffer, int32_t maxLen)
 cdrMemoryStream::cdrMemoryStream(const cdrMemoryStream& obj)
 {
   out_c=0;
+  in_c=0;
   byte_order=obj.byte_order;
   out_len= obj.out_len;
 
@@ -494,6 +497,7 @@ void cdrMemoryStream::rewindInputPtr(){
 
 void cdrMemoryStream::rewindPtrs(){
   out_c = 0;
+  in_c = 0;
   return;
 }
 
@@ -536,7 +540,7 @@ void cdrStream::get_octet_array(char *octet, int32_t size, int32_t align){
 
 void cdrStream::put_octet_array(char *octet, int32_t size, int32_t align){
   int pad;
-  int pos = out_c; 
+  int pos = in_c; 
 
   if((pad = pos % align)) pos += align - pad;
   if(pos+size > out_len){
@@ -545,7 +549,7 @@ void cdrStream::put_octet_array(char *octet, int32_t size, int32_t align){
     out_len=size+pos;
   }
   memcpy((void *)((char *)out_buf+pos), octet, size);
-  out_c = pos+size;
+  in_c = pos+size;
   return;
 }
 
@@ -573,7 +577,7 @@ int  cdrMemoryStream::checkInputOverrun(uint32_t itemSize, uint32_t nItems, int 
 int32_t cdrMemoryStream::checkOutputOverrun(uint32_t itemSize, uint32_t nItems, int32_t align){
 
   int pad;
-  int pos = out_c; 
+  int pos = in_c; 
 
   if((pad=pos % align)) pos += align - pad;
   if(pos+itemSize*nItems > out_len) return 1;


### PR DESCRIPTION
cdrStreamのput_octet_array関数でデータを書き込んだ後、get_octet_array関数でデータを読み込もうとするとデータの最後のポインタからの長さを読み込もうとする。
これはデータの読み込み位置と書き込み位置を格納する変数が同一になっていることが原因のため、区別するようにした。