### PR TITLE
cdrStream.hのMarshal、Unmarshalの定義に問題があるため修正

### DIFF
--- a/include/RtORB/cdrStream.h
+++ b/include/RtORB/cdrStream.h
@@ -90,13 +90,13 @@ public:
  int32_t _ref;                  /*!< (TODO) */
 
 #define Marshal(s, type, align, a)  do{\
-   int32_t len = sizeof(type); 	\
-   s.put_octet_array((char *) a, len, align); 	\
+   int32_t __len = sizeof(type); 	\
+   s.put_octet_array((char *) a, __len, align); 	\
   }while(0)  /*!< (TODO) */
 
 #define Unmarshal(s, type, align, a) do{\
-   int32_t len = sizeof(type); 	\
-   s.get_octet_array((char *) a, len, align); 	\
+   int32_t __len = sizeof(type); 	\
+   s.get_octet_array((char *) a, __len, align); 	\
  }while(0);  /*!< (TODO) */
 
 /*!


### PR DESCRIPTION
cdrStream.hでマクロで定義されているMarshal、Unmarshalで問題が発生することがある。
これはMarshal、Unmarshalのマクロで`len`という変数を記述しているが、置き換えた箇所のスコープにも同じ名前の変数があることが原因のため変数名を変更した。