### PR TITLE
符号化、復号時にOctetの配列をmemcpyするように変更

### DIFF
--- a/lib/CXX/cdrStream.cpp
+++ b/lib/CXX/cdrStream.cpp
@@ -88,11 +88,19 @@ void cdrStream::marshal_sequence(void *buf, int32_t size, CORBA_TypeCode tc){
 
   _ptr = (char *)buf;
   _buf = (octet *)RtORB_alloc(1024,"marshal_sequence");
-  for(int i=0 ; i < size ; i++){
-    len=0;
-    marshal_by_typecode(_buf, _ptr, _tc, &len);
-    put_octet_array((char *)_buf, len, _tc->alignment);
-    _ptr = _ptr + _tc->size;
+  if(_tc->size == 1)
+  {
+    put_octet_array((char *)_buf, size*_tc->size, _tc->alignment);
+    _ptr = _ptr + size*_tc->size;
+  }
+  else
+  {
+    for(int i=0 ; i < size ; i++){
+      len=0;
+      marshal_by_typecode(_buf, _ptr, _tc, &len);
+      put_octet_array((char *)_buf, len, _tc->alignment);
+      _ptr = _ptr + _tc->size;
+    }
   }
   RtORB_free(_buf,"marshal_sequence");
   return;
@@ -109,9 +117,17 @@ void *cdrStream::unmarshal_sequence(int32_t size, CORBA_TypeCode tc){
   _ptr = (char *)res;
   len=12;
   Address_Alignment(&len, _tc->alignment);
-  for(i=0;i<size;i++){
-    demarshal_by_typecode((void **)_ptr, _tc, (octet *)out_buf, &len, byte_order);
-    _ptr +=  _tc->size;
+  if(_tc->size == 1)
+  {
+      memcpy(_ptr, out_buf, size*_tc->size);
+      _ptr +=  size*_tc->size;
+  }
+  else
+  {
+    for(i=0;i<size;i++){
+      demarshal_by_typecode((void **)_ptr, _tc, (octet *)out_buf, &len, byte_order);
+      _ptr +=  _tc->size;
+    }
   }
   return res;
 }

--- a/lib/allocater.c
+++ b/lib/allocater.c
@@ -152,12 +152,20 @@ RtORB_free_by_typecode(CORBA_TypeCode tc, void *val, int32_t flag){
 	     int32_t len = size_of_typecode(_tc, F_DEMARSHAL);
 	     int32_t base = align_of_typecode(_tc, F_DEMARSHAL);
 
-	     for(i=0;i<sb->_length;i++){
-	       Address_Alignment(&align, base);
-               tmp = (void **)((long)buf + align); 
-               RtORB_free_by_typecode(_tc, tmp, 0);
-	       align += len ;
-	     }
+      if(_tc->size == 1)
+       {
+        Address_Alignment(&align, base);
+        align += sb->_length;
+       }
+       else
+       {
+        for(i=0;i<sb->_length;i++){
+          Address_Alignment(&align, base);
+          tmp = (void **)((long)buf + align); 
+          RtORB_free_by_typecode(_tc, tmp, 0);
+          align += len ;
+        }
+       }
              if(sb->_buffer){
                RtORB_free(sb->_buffer, "RtORB_free_by_typecode(sequence)");
              }
@@ -253,13 +261,20 @@ RtORB_free_by_typecode_cpp(CORBA_TypeCode tc, void *val, int32_t flag){
 	     CORBA_TypeCode _tc = tc->member_type[0];
 	     int32_t len = size_of_typecode(_tc, F_DEMARSHAL);
 	     int32_t base = align_of_typecode(_tc, F_DEMARSHAL);
-
-	     for(i=0;i<sb->_length;i++){
-	       Address_Alignment(&align, base);
-               tmp = (void **)((long)buf + align); 
-               RtORB_free_by_typecode_cpp(_tc, tmp, 0);
-	       align += len ;
-	     }
+       if(_tc->size == 1)
+       {
+         Address_Alignment(&align, base);
+        align += sb->_length;
+       }
+       else
+       {
+        for(i=0;i<sb->_length;i++){
+          Address_Alignment(&align, base);
+                tmp = (void **)((long)buf + align); 
+                RtORB_free_by_typecode_cpp(_tc, tmp, 0);
+          align += len ;
+        }
+       }
              if(sb->_buffer){
                RtORB_free(sb->_buffer, "RtORB_free_by_typecode_cpp(sequence)");
              }
@@ -457,7 +472,8 @@ RtORB_Result__free_cpp(CORBA_TypeCode tc, void **result){
  */
 void *
 RtORB_typecode_alloc(CORBA_TypeCode tc){
-  return (void *)RtORB_calloc(size_of_typecode(tc, F_DEMARSHAL), 1, "RtORB_typecode_alloc");
+  //return (void *)RtORB_calloc(size_of_typecode(tc, F_DEMARSHAL), 1, "RtORB_typecode_alloc");
+  return (void *)RtORB_alloc(size_of_typecode(tc, F_DEMARSHAL), "RtORB_typecode_alloc");
 }
 /*
  * void


### PR DESCRIPTION
符号化、復号で配列を扱うときにforループにより遅くなるため、Octet配列の場合はmemcpyでコピーするように変更した。