### PR TITLE
CORBA_Object_is_equivalent関数で正しくオブジェクトが比較できない問題の修正

### DIFF
--- a/lib/orb.c
+++ b/lib/orb.c
@@ -646,10 +646,10 @@ CORBA_Object_is_equivalent(CORBA_Object object,
   if (!object || !other_object) { return FALSE; }
 
   /* First, compare typedId if exist. They might be empty. */
-  if(object->typedId && other_object->typedId
-     && strcmp((char *)object->typedId, (const char *)other_object->typedId) == 0) {
-    return TRUE;
-  }
+  //if(object->typedId && other_object->typedId
+  //   && strcmp((char *)object->typedId, (const char *)other_object->typedId) == 0) {
+  //  return TRUE;
+  //}
   /* Second, compare object_key */
   if (object->object_key && object->object_key &&
       strcmp((char *)object->object_key, (const char *)other_object->object_key) == 0) {


### PR DESCRIPTION
CORBA_Object_is_equivalent関数でtypedIDが同じ場合は同一のオブジェクトと判定されるが、タイプ名が同じというだけで同一と判定するとデータポートは全て同一オブジェクトと判定するなどしてしまうため消去した。