### PR TITLE
#8の変更にミスがあったため修正

### DIFF
--- a/lib/giop-marshal.c
+++ b/lib/giop-marshal.c
@@ -155,7 +155,8 @@ uint32_t size_of_typecode(CORBA_TypeCode tc, int flag)
        return sizeof(CORBA_Object);
 
     case tk_string:
-       return 4;
+      if(flag == F_MARSHAL) return 4;
+      return sizeof(void *);
 
     default:
       if (tc->size) return tc->size;


### PR DESCRIPTION
#8 の変更でsize_of_typecode関数内の`sizeof(void *)`を返す場所を`retuen 4`に変更したが、こうすると動作しなくなるため元に戻した。
ただこれでは32bitと64bitでサイズが異なってしまうため偶然正常に動作しているだけの可能性がある。