### PR TITLE
string_to_object関数の返り値が間違っているため修正

### DIFF
--- a/lib/CXX/orb.cc
+++ b/lib/CXX/orb.cc
@@ -110,7 +110,7 @@ namespace CORBA
     CORBA_Object obj = CORBA_ORB_string_to_object(_impl, (unsigned char*)str, &ev);
 
     catchAndThrowDefaultException(&ev);
-    return Object_ptr(obj);
+    return Object_ptr(new Object(obj));
   }
 
   void ORB::run() {


### PR DESCRIPTION
string_to_object関数でObject_ptrの引数にCORBA_Object型を指定しているが、CORBA::Object型を入れないと落ちるため修正した。