### PR TITLE
ビルドの依存関係の修正

### DIFF
--- a/CosName/CMakeLists.txt
+++ b/CosName/CMakeLists.txt
@@ -24,7 +24,7 @@ set(SOURCES NameService.c)
 
 
 link_directories(${CMAKE_SOURCE_DIR}/lib ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/include/RtORB/ /usr/local/lib/) 
-include_directories(${CMAKE_SOURCE_DIR}/lib ${CMAKE_SOURCE_DIR}/include ${CMAKE_BINARY_DIR}/lib/CosName)
+include_directories(${CMAKE_SOURCE_DIR}/lib ${CMAKE_SOURCE_DIR}/include ${CMAKE_BINARY_DIR}/lib/CosName ${CMAKE_BINARY_DIR}/include)
 
 
 #add_custom_command( OUTPUT ${OUTPUT_SOURCES}
@@ -36,6 +36,7 @@ include_directories(${CMAKE_SOURCE_DIR}/lib ${CMAKE_SOURCE_DIR}/include ${CMAKE_
 
 
 add_executable(${TARGET} ${SOURCES})
+add_dependencies(${TARGET} RtORB)
 target_link_libraries(${TARGET} pthread RtORB )
 
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -53,6 +53,8 @@ add_custom_command( OUTPUT ${OUTPUT_SOURCES}
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/CosName
   )
 
+add_custom_target(RTORB_IDLTGT DEPENDS ${OUTPUT_SOURCES})
+add_dependencies(RTORB_IDLTGT rtorb-idl)
 
 
 IF("${OS_NAME}" MATCHES "FreeBSD")
@@ -68,11 +70,14 @@ IF("${OS_NAME}" MATCHES "CYGWIN_NT-5.1")
 
 link_directories(${GLIB_LIBRARY_DIRS} ${IDL_LIBRARY_DIRS} ${UUID_LIBRARY_DIRS})
 add_library(${TARGET} SHARED ${SOURCES})
+add_dependencies(${TARGET} RTORB_IDLTGT)
 ELSE()
 link_directories(${GLIB_LIBRARY_DIRS} ${IDL_LIBRARY_DIRS} ${UUID_LIBRARY_DIRS})
 add_library(${TARGET} SHARED ${SOURCES})
+add_dependencies(${TARGET} RTORB_IDLTGT)
 SET_TARGET_PROPERTIES(${TARGET} PROPERTIES CLEAN_DIRECT_OUTPUT 1)
 add_library(${TARGET}-static STATIC ${SOURCES})
+add_dependencies(${TARGET}-static RTORB_IDLTGT)
 set_target_properties(${TARGET}-static PROPERTIES OUTPUT_NAME "RtORB")
 set_target_properties(${TARGET}-static PROPERTIES PREFIX "lib")
 SET_TARGET_PROPERTIES(${TARGET}-static PROPERTIES CLEAN_DIRECT_OUTPUT 1)

--- a/lib/CXX/CMakeLists.txt
+++ b/lib/CXX/CMakeLists.txt
@@ -12,7 +12,7 @@ add_definitions(-D${OS_NAME} -DUSE_UUID)
 ENDIF()
 
 
-include_directories(/usr/include ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/lib ${CMAKE_SOURCE_DIR}/CosName)
+include_directories(/usr/include ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/lib ${CMAKE_SOURCE_DIR}/CosName ${CMAKE_BINARY_DIR}/include)
 
 #add_definitions(-fPIC)
 
@@ -20,8 +20,10 @@ link_directories(${GLIB_LIBRARY_DIR} ${IDL_LIBRARY_DIR} ${CMAKE_SOURCE_DIR}/lib)
 
 
 add_library(${TARGET} SHARED ${SOURCES})
+add_dependencies(${TARGET} RtORB)
 SET_TARGET_PROPERTIES(${TARGET} PROPERTIES CLEAN_DIRECT_OUTPUT 1)
 add_library(${TARGET}-static STATIC ${SOURCES})
+add_dependencies(${TARGET}-static RtORB-static)
 set_target_properties(${TARGET}-static PROPERTIES OUTPUT_NAME "RtORB_cpp")
 set_target_properties(${TARGET}-static PROPERTIES PREFIX "lib")
 SET_TARGET_PROPERTIES(${TARGET}-static PROPERTIES CLEAN_DIRECT_OUTPUT 1)


### PR DESCRIPTION
ビルドの依存関係によりIDLコンパイルする前にRtORB本体のビルドを行う可能性があるため修正した。